### PR TITLE
Rework CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,60 +1,60 @@
 pipeline {
     options {
-        skipDefaultCheckout()
         buildDiscarder(logRotator(numToKeepStr: '20'))
+        timestamps()
     }
-    agent { label 'd3-build-agent' }
+    agent {
+        docker {
+            label 'd3-build-agent'
+            image 'openjdk:8-jdk-alpine'
+            args '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp'
+        }
+    }
     stages {
-        stage('Tests') {
+        stage('Build') {
             steps {
                 script {
-                    checkout scm
-                    docker.image("gradle:5.4-jdk8-slim")
-                            .inside("-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp") {
-                        sh "gradle test --info"
-                        sh "gradle compileIntegrationTestKotlin --info"
-                        sh "gradle integrationTest --info"
-                        sh "gradle d3TestReport"
-                    }
-                publishHTML (target: [
-                    allowMissing: false,
-                    alwaysLinkToLastBuild: false,
-                    keepAll: true,
-                    reportDir: 'build/reports',
-                    reportFiles: 'd3-test-report.html',
-                    reportName: "D3 test report"
-                ])
-                }
-            }
-            post {
-                cleanup {
-                    cleanWs()
+                    sh "./gradlew build --info"
                 }
             }
         }
-        stage('Build and push docker images') {
-          agent { label 'd3-build-agent' }
-          steps {
-            script {
-              def scmVars = checkout scm
-  if (env.BRANCH_NAME ==~ /(master|develop|reserved)/ || env.TAG_NAME) {
-                withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
-
-                  TAG = env.TAG_NAME ? env.TAG_NAME : env.BRANCH_NAME
-                  iC = docker.image("gradle:4.10.2-jdk8-slim")
-                  iC.inside(" -e JVM_OPTS='-Xmx3200m' -e TERM='dumb'"+
-                  " -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp"+
-                  " -e DOCKER_REGISTRY_URL='https://nexus.iroha.tech:19002'"+
-                  " -e DOCKER_REGISTRY_USERNAME='${login}'"+
-                  " -e DOCKER_REGISTRY_PASSWORD='${password}'"+
-                  " -e TAG='${TAG}'") {
-                    sh "gradle shadowJar"
-                    sh "gradle dockerPush"
-                  }
-                 }
-              }
+        stage('Test') {
+            steps {
+                script {
+                    sh "./gradlew test --info"
+                }
             }
-          }
+        }
+        stage('Build artifacts') {
+            steps {
+                script {
+                    if (env.BRANCH_NAME ==~ /(master|develop)/ || env.TAG_NAME) {
+                        DOCKER_TAGS = ['master': 'latest', 'develop': 'develop']
+                        withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
+                          env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19002"
+                          env.DOCKER_REGISTRY_USERNAME = "${login}"
+                          env.DOCKER_REGISTRY_PASSWORD = "${password}"
+                          env.TAG = env.TAG_NAME ? env.TAG_NAME : DOCKER_TAGS[env.BRANCH_NAME]
+                          sh "./gradlew dockerPush"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            publishHTML (target: [
+                allowMissing: false,
+                alwaysLinkToLastBuild: false,
+                keepAll: true,
+                reportDir: 'build/reports',
+                reportFiles: 'd3-test-report.html',
+                reportName: "D3 test report"
+            ])
+        }
+        cleanup {
+            cleanWs()
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,3 +52,7 @@ allprojects {
         kotlinOptions.jvmTarget = "1.8"
     }
 }
+
+project.afterEvaluate {
+    test.finalizedBy(d3TestReport)
+}

--- a/changelog-endpoint/build.gradle
+++ b/changelog-endpoint/build.gradle
@@ -108,11 +108,7 @@ task integrationTest(type: Test) {
     // Enable JUnit5 tests
     useJUnitPlatform {
     }
-
-    mustRunAfter test
 }
-check.dependsOn integrationTest
-
 
 compileKotlin {
     kotlinOptions {
@@ -123,4 +119,10 @@ compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+}
+
+project.afterEvaluate {
+    dockerfileCreate.dependsOn(shadowJar)
+    integrationTest.dependsOn(dockerfileCreate)
+    test.finalizedBy(integrationTest)
 }


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

Rework Jenkinsfile to simplify workflow. There is a missing functionality that must be first implemented in Gradle before this version of CI will pass.
- [x] Replace `compileIntegrationTestKotlin`, `integrationTest`, `d3TestReport` with a single `gradle test` invocation. `gradle test` should support toggling different test types via command options. E.g., `gradle test --unit --integraion` (or something similar).